### PR TITLE
Refactor tostring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /target
 /.classpath
+
+*.java~

--- a/src/main/java/com/sforce/ws/codegen/metadata/ComplexClassMetadata.java
+++ b/src/main/java/com/sforce/ws/codegen/metadata/ComplexClassMetadata.java
@@ -15,6 +15,7 @@
  */
 package com.sforce.ws.codegen.metadata;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -68,6 +69,19 @@ public class ComplexClassMetadata extends ClassMetadata {
 
     public List<MemberMetadata> getMemberMetadataList() {
         return this.memberMetadataList;
+    }
+
+    private final static int MAX_SPLIT_SIZE = 500;
+    public List<List<MemberMetadata>> getSplitMemberMetadataList() {
+        int start = 0;
+        int end = 0;
+        ArrayList<List<MemberMetadata>> result = new ArrayList<>(1+(memberMetadataList.size()/MAX_SPLIT_SIZE));
+        while (start < memberMetadataList.size()) {
+            end = Math.min(start+MAX_SPLIT_SIZE, memberMetadataList.size());
+            result.add(memberMetadataList.subList(start, end));
+            start = end;
+        }
+        return result;
     }
 
     public boolean getGenerateInterfaces() {

--- a/src/main/java/com/sforce/ws/codegen/templates/type.st
+++ b/src/main/java/com/sforce/ws/codegen/templates/type.st
@@ -88,30 +88,25 @@ $gen.memberMetadataList:{ member |
         $member.setMethodName$(__in, __typeMapper);
 }$    }
 
-    private static final String[] MEMBER_NAMES = {
-      $gen.memberMetadataList: { member |
-      "$member.fieldName$",
-}$
-    };
-    
     @Override
     public String toString() {
-      Object[] memberValues = {
-      $gen.memberMetadataList: { member |
-        $member.fieldName$,
-}$
-      };
       java.lang.StringBuilder sb = new java.lang.StringBuilder();
       sb.append("[$gen.className$ ");
-$gen.superToString$
-      for (i = 0; i < MEMBER_NAMES.length; i++) {
-        sb.append(' ')
-           .append(MEMBER_NAMES[i])
-           .append("='")
-           .append(com.sforce.ws.util.Verbose.toString(memberValues[i]))
-           .append("'\\n");
-      }
+      $gen.superToString$
+      $gen.splitMemberMetadataList: { split | toString$i$(sb);
+}$
       return sb.toString();
+    }
+
+$gen.splitMemberMetadataList: { split |
+    private void toString$i$(StringBuilder sb) {
+      $split:{ member | toStringHelper(sb, "$member.fieldName$", $member.fieldName$);
+}$
+    \}
+}$
+    
+    private void toStringHelper(StringBuilder sb, String name, Object value) {
+      sb.append('"').append(name).append('"').append('=').append(com.sforce.ws.util.Verbose.toString(value));
     }
     
     $if(gen.generateInterfaces && gen.hasArrayField)$

--- a/src/main/java/com/sforce/ws/codegen/templates/type.st
+++ b/src/main/java/com/sforce/ws/codegen/templates/type.st
@@ -103,6 +103,7 @@ $gen.memberMetadataList:{ member |
       };
       java.lang.StringBuilder sb = new java.lang.StringBuilder();
       sb.append("[$gen.className$ ");
+$gen.superToString$
       for (i = 0; i < MEMBER_NAMES.length; i++) {
         sb.append(' ')
            .append(MEMBER_NAMES[i])

--- a/src/main/java/com/sforce/ws/codegen/templates/type.st
+++ b/src/main/java/com/sforce/ws/codegen/templates/type.st
@@ -87,14 +87,29 @@ $gen.memberMetadataList: { member |
 $gen.memberMetadataList:{ member |
         $member.setMethodName$(__in, __typeMapper);
 }$    }
+
+    private static final String[] MEMBER_NAMES = {
+      $gen.memberMetadataList: { member |
+      "$member.fieldName$",
+}$
+    };
     
     @Override
     public String toString() {
+      Object[] memberValues = {
+      $gen.memberMetadataList: { member |
+        $member.fieldName$,
+}$
+      };
       java.lang.StringBuilder sb = new java.lang.StringBuilder();
       sb.append("[$gen.className$ ");
-      $gen.superToString$$gen.memberMetadataList: { member |
-      sb.append(" $member.fieldName$='").append(com.sforce.ws.util.Verbose.toString($member.fieldName$)).append("'\\n");
-}$      sb.append("]\\n");
+      for (i = 0; i < MEMBER_NAMES.length; i++) {
+        sb.append(' ')
+           .append(MEMBER_NAMES[i])
+           .append("='")
+           .append(com.sforce.ws.util.Verbose.toString(memberValues[i]))
+           .append("'\\n");
+      }
       return sb.toString();
     }
     

--- a/src/test/resources/codegeneration/EmailSyncEntity.java
+++ b/src/test/resources/codegeneration/EmailSyncEntity.java
@@ -282,19 +282,40 @@ public class EmailSyncEntity implements com.sforce.ws.bind.XMLizable {
         setSyncFollowed(__in, __typeMapper);
     }
 
+    private static final String[] MEMBER_NAMES = {
+            "conflictResolution",
+            "dataSetFilter",
+            "fieldMapping",
+            "matchPreference",
+            "name",
+            "recordTypeId",
+            "syncDirection",
+            "syncFollowed",
+
+    };
+
     @Override
     public String toString() {
+      Object[] memberValues = {
+              conflictResolution,
+              dataSetFilter,
+              fieldMapping,
+              matchPreference,
+              name,
+              recordTypeId,
+              syncDirection,
+              syncFollowed,
+
+      };
       java.lang.StringBuilder sb = new java.lang.StringBuilder();
       sb.append("[EmailSyncEntity ");
-      sb.append(" conflictResolution='").append(com.sforce.ws.util.Verbose.toString(conflictResolution)).append("'\n");
-      sb.append(" dataSetFilter='").append(com.sforce.ws.util.Verbose.toString(dataSetFilter)).append("'\n");
-      sb.append(" fieldMapping='").append(com.sforce.ws.util.Verbose.toString(fieldMapping)).append("'\n");
-      sb.append(" matchPreference='").append(com.sforce.ws.util.Verbose.toString(matchPreference)).append("'\n");
-      sb.append(" name='").append(com.sforce.ws.util.Verbose.toString(name)).append("'\n");
-      sb.append(" recordTypeId='").append(com.sforce.ws.util.Verbose.toString(recordTypeId)).append("'\n");
-      sb.append(" syncDirection='").append(com.sforce.ws.util.Verbose.toString(syncDirection)).append("'\n");
-      sb.append(" syncFollowed='").append(com.sforce.ws.util.Verbose.toString(syncFollowed)).append("'\n");
-      sb.append("]\n");
+      for (i = 0; i < MEMBER_NAMES.length; i++) {
+        sb.append(' ')
+           .append(MEMBER_NAMES[i])
+           .append("='")
+           .append(com.sforce.ws.util.Verbose.toString(memberValues[i]))
+           .append("'\n");
+      }
       return sb.toString();
     }
 

--- a/src/test/resources/codegeneration/EmailSyncEntity.java
+++ b/src/test/resources/codegeneration/EmailSyncEntity.java
@@ -282,41 +282,30 @@ public class EmailSyncEntity implements com.sforce.ws.bind.XMLizable {
         setSyncFollowed(__in, __typeMapper);
     }
 
-    private static final String[] MEMBER_NAMES = {
-            "conflictResolution",
-            "dataSetFilter",
-            "fieldMapping",
-            "matchPreference",
-            "name",
-            "recordTypeId",
-            "syncDirection",
-            "syncFollowed",
-
-    };
-
     @Override
     public String toString() {
-      Object[] memberValues = {
-              conflictResolution,
-              dataSetFilter,
-              fieldMapping,
-              matchPreference,
-              name,
-              recordTypeId,
-              syncDirection,
-              syncFollowed,
-
-      };
       java.lang.StringBuilder sb = new java.lang.StringBuilder();
       sb.append("[EmailSyncEntity ");
-      for (i = 0; i < MEMBER_NAMES.length; i++) {
-        sb.append(' ')
-           .append(MEMBER_NAMES[i])
-           .append("='")
-           .append(com.sforce.ws.util.Verbose.toString(memberValues[i]))
-           .append("'\n");
-      }
+      toString1(sb);
+
       return sb.toString();
+    }
+
+    private void toString1(StringBuilder sb) {
+      toStringHelper(sb, "conflictResolution", conflictResolution);
+      toStringHelper(sb, "dataSetFilter", dataSetFilter);
+      toStringHelper(sb, "fieldMapping", fieldMapping);
+      toStringHelper(sb, "matchPreference", matchPreference);
+      toStringHelper(sb, "name", name);
+      toStringHelper(sb, "recordTypeId", recordTypeId);
+      toStringHelper(sb, "syncDirection", syncDirection);
+      toStringHelper(sb, "syncFollowed", syncFollowed);
+
+    }
+
+
+    private void toStringHelper(StringBuilder sb, String name, Object value) {
+      sb.append('"').append(name).append('"').append('=').append(com.sforce.ws.util.Verbose.toString(value));
     }
 
 }

--- a/src/test/resources/codegeneration/EmailSyncEntityInterface.java
+++ b/src/test/resources/codegeneration/EmailSyncEntityInterface.java
@@ -299,41 +299,30 @@ public class EmailSyncEntity implements com.sforce.ws.bind.XMLizable , IEmailSyn
         setSyncFollowed(__in, __typeMapper);
     }
 
-    private static final String[] MEMBER_NAMES = {
-            "conflictResolution",
-            "dataSetFilter",
-            "fieldMapping",
-            "matchPreference",
-            "name",
-            "recordTypeId",
-            "syncDirection",
-            "syncFollowed",
-
-    };
-
     @Override
     public String toString() {
-      Object[] memberValues = {
-              conflictResolution,
-              dataSetFilter,
-              fieldMapping,
-              matchPreference,
-              name,
-              recordTypeId,
-              syncDirection,
-              syncFollowed,
-
-      };
       java.lang.StringBuilder sb = new java.lang.StringBuilder();
       sb.append("[EmailSyncEntity ");
-      for (i = 0; i < MEMBER_NAMES.length; i++) {
-        sb.append(' ')
-           .append(MEMBER_NAMES[i])
-           .append("='")
-           .append(com.sforce.ws.util.Verbose.toString(memberValues[i]))
-           .append("'\n");
-      }
+      toString1(sb);
+
       return sb.toString();
+    }
+
+    private void toString1(StringBuilder sb) {
+      toStringHelper(sb, "conflictResolution", conflictResolution);
+      toStringHelper(sb, "dataSetFilter", dataSetFilter);
+      toStringHelper(sb, "fieldMapping", fieldMapping);
+      toStringHelper(sb, "matchPreference", matchPreference);
+      toStringHelper(sb, "name", name);
+      toStringHelper(sb, "recordTypeId", recordTypeId);
+      toStringHelper(sb, "syncDirection", syncDirection);
+      toStringHelper(sb, "syncFollowed", syncFollowed);
+
+    }
+
+
+    private void toStringHelper(StringBuilder sb, String name, Object value) {
+      sb.append('"').append(name).append('"').append('=').append(com.sforce.ws.util.Verbose.toString(value));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/resources/codegeneration/EmailSyncEntityInterface.java
+++ b/src/test/resources/codegeneration/EmailSyncEntityInterface.java
@@ -299,19 +299,40 @@ public class EmailSyncEntity implements com.sforce.ws.bind.XMLizable , IEmailSyn
         setSyncFollowed(__in, __typeMapper);
     }
 
+    private static final String[] MEMBER_NAMES = {
+            "conflictResolution",
+            "dataSetFilter",
+            "fieldMapping",
+            "matchPreference",
+            "name",
+            "recordTypeId",
+            "syncDirection",
+            "syncFollowed",
+
+    };
+
     @Override
     public String toString() {
+      Object[] memberValues = {
+              conflictResolution,
+              dataSetFilter,
+              fieldMapping,
+              matchPreference,
+              name,
+              recordTypeId,
+              syncDirection,
+              syncFollowed,
+
+      };
       java.lang.StringBuilder sb = new java.lang.StringBuilder();
       sb.append("[EmailSyncEntity ");
-      sb.append(" conflictResolution='").append(com.sforce.ws.util.Verbose.toString(conflictResolution)).append("'\n");
-      sb.append(" dataSetFilter='").append(com.sforce.ws.util.Verbose.toString(dataSetFilter)).append("'\n");
-      sb.append(" fieldMapping='").append(com.sforce.ws.util.Verbose.toString(fieldMapping)).append("'\n");
-      sb.append(" matchPreference='").append(com.sforce.ws.util.Verbose.toString(matchPreference)).append("'\n");
-      sb.append(" name='").append(com.sforce.ws.util.Verbose.toString(name)).append("'\n");
-      sb.append(" recordTypeId='").append(com.sforce.ws.util.Verbose.toString(recordTypeId)).append("'\n");
-      sb.append(" syncDirection='").append(com.sforce.ws.util.Verbose.toString(syncDirection)).append("'\n");
-      sb.append(" syncFollowed='").append(com.sforce.ws.util.Verbose.toString(syncFollowed)).append("'\n");
-      sb.append("]\n");
+      for (i = 0; i < MEMBER_NAMES.length; i++) {
+        sb.append(' ')
+           .append(MEMBER_NAMES[i])
+           .append("='")
+           .append(com.sforce.ws.util.Verbose.toString(memberValues[i]))
+           .append("'\n");
+      }
       return sb.toString();
     }
 


### PR DESCRIPTION
Old mechanism of generating toString was resulting in “code to large”
errors. This new mechanism should be impervious to that for toString.
It can be employed for other methods too if they become problematic.
